### PR TITLE
authnRequest ID is a placeholder

### DIFF
--- a/roles/shibboleth/templates/shibboleth2.xml.j2
+++ b/roles/shibboleth/templates/shibboleth2.xml.j2
@@ -23,7 +23,12 @@
              signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
              >
          <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-             xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="spid.agid.gov.it" Version="2.0" IssueInstant="2017-01-01T00:00:00Z" AssertionConsumerServiceIndex="0" AttributeConsumingServiceIndex="0">
+             xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+             ID="_FOO"
+             Version="2.0"
+             IssueInstant="2017-01-01T00:00:00Z"
+             AssertionConsumerServiceIndex="0"
+             AttributeConsumingServiceIndex="0">
              <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" NameQualifier="spid.agid.gov.it">https://spid.agid.gov.it</saml:Issuer>
          </samlp:AuthnRequest>
       </SessionInitiator>


### PR DESCRIPTION
Secondo [la documentazione del sessionInitiator](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPSessionInitiator#NativeSPSessionInitiator-ChildElements) l'elemento ID nel template della authnRequest è un semplice template che può assumere qualunque valore (tanto sarà riscritto durante la richiesta).
Mi sembra sfortunato usare lo entityID in questo punto perché il lettore potrebbe essere tentato di modificarlo mentre ogni stringa va bene.
Mi sembrava che la stringa _FOO chiarisse la funzione del valore di questo attributo.