### PR TITLE
Replace "installed" with "present" in ansible roles

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: "Docker deve essere installato"
-  apt: pkg=docker.io state=installed
+  apt: pkg=docker.io state=present
 
 - name: "PIP deve essere installato"
-  apt: pkg=python-pip state=installed
+  apt: pkg=python-pip state=present
 
 - name: "docker-py deve essere installato"
   pip: name=docker-py


### PR DESCRIPTION
According to [the Ansible docs](https://docs.ansible.com/ansible/latest/modules/apt_module.html), `installed` is not an allowed value for the `apt` role. This PR replaces it with `present`.